### PR TITLE
Fix non nullable columns

### DIFF
--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -92,7 +92,7 @@ def define_schema(field, name):
                 field = types
             
     if isinstance(field['type'], list):
-        if field['type'][0] == "null" or field['type'][1] == "null":
+        if ("null" in field['type']):
             schema_mode = 'NULLABLE'
         else:
             schema_mode = 'required'


### PR DESCRIPTION
Some columns have only 1 type defined in the schema. Hence,
we should try to read the 2th element of such arrays.