### PR TITLE
Fix dependencies issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,17 @@ setup(name='target-bigquery',
       url='https://github.com/RealSelf/target-bigquery',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['target_bigquery'],
+      setup_requires=['wheel'],
       install_requires=[
           'jsonschema==2.6.0',
           'singer-python>=1.5.0',
-          'google-api-python-client>=1.6.2',
+          'google-api-python-client>=1.12.3',
           'google-cloud>=0.34.0',
-          'google-cloud-bigquery>=1.9.0',
-          'google-auth'
+          'google-cloud-bigquery>=1.24.0',
+          'google-auth',
+          'google-api-core[grpc]>=1.22.3',
+          'pytz==2018.4',
+          'setuptools>=40.3.0'
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
For some unknown reason, the 'grpc' extra dependency of google-api-core
is now both needed at runtime and not installed if not explicitely mentionned
in the dependencies list.

This commit is also bumping the version of some Google libs.

As Google libs expects recent versions of setuptools, we ask to get a newer one.

To conclude, the singer python SDK only works with a specific version of
pytz so we have to explicit it to avoid having pip resolve a version that is
too new.